### PR TITLE
Delegate server responses to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,3 +188,25 @@ JSON event log:
 ```
 
 See more examples [here](docs/EXAMPLES.md).
+## Library Usage
+
+The `galah` package can be used as a standalone library. Create a `galah.Service` and call `GenerateHTTPResponse` with an `http.Request` to produce a response.
+
+```go
+svc, err := galah.NewService(context.Background(), galah.Options{
+    LLMProvider: "openai",
+    LLMModel:    "gpt-4.1-mini",
+    LLMAPIKey:   "YOUR_KEY",
+})
+if err != nil {
+    log.Fatal(err)
+}
+req, _ := http.NewRequest("GET", "https://example.com", nil)
+respBytes, err := svc.GenerateHTTPResponse(req, "8080")
+if err != nil {
+    log.Fatal(err)
+}
+fmt.Println(string(respBytes))
+```
+
+

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/0x4d31/galah/galah"
 	"github.com/0x4d31/galah/internal/cache"
 	"github.com/0x4d31/galah/internal/config"
 	el "github.com/0x4d31/galah/internal/logger"
@@ -29,6 +30,7 @@ type App struct {
 	LLMConfig   llm.Config
 	Logger      *logrus.Logger
 	Model       llms.Model
+	Service     *galah.Service
 	Suricata    *suricata.RuleSet
 	Servers     map[uint16]*http.Server
 }
@@ -58,6 +60,17 @@ func (a *App) Run() error {
 		logger.Fatalf("error initializing app: %s", err)
 	}
 
+	a.Service = &galah.Service{
+		Cache:         a.Cache,
+		CacheDuration: args.CacheDuration,
+		Config:        a.Config,
+		Rules:         a.Rules,
+		EventLogger:   a.EventLogger,
+		LLMConfig:     a.LLMConfig,
+		Logger:        a.Logger,
+		Model:         a.Model,
+	}
+
 	srv := server.Server{
 		Cache:         a.Cache,
 		CacheDuration: args.CacheDuration,
@@ -68,6 +81,7 @@ func (a *App) Run() error {
 		LLMConfig:     a.LLMConfig,
 		Logger:        a.Logger,
 		Model:         a.Model,
+		Service:       a.Service,
 		Suricata:      a.Suricata,
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/0x4d31/galah/galah"
 	"github.com/0x4d31/galah/internal/app"
 	"github.com/0x4d31/galah/internal/config"
 	"github.com/0x4d31/galah/internal/server"
@@ -45,6 +46,7 @@ func TestStartServers(t *testing.T) {
 				LLMConfig:   a.LLMConfig,
 				Logger:      a.Logger,
 				Model:       a.Model,
+				Service:     &galah.Service{},
 			}
 			err := srv.StartServers()
 
@@ -90,6 +92,7 @@ func TestStartHTTPServer(t *testing.T) {
 				LLMConfig:   a.LLMConfig,
 				Logger:      a.Logger,
 				Model:       a.Model,
+				Service:     &galah.Service{},
 			}
 			HTTPServer := srv.SetupServer(tt.portConfig)
 
@@ -154,6 +157,7 @@ func TestStartTLSServer(t *testing.T) {
 				LLMConfig:   a.LLMConfig,
 				Logger:      a.Logger,
 				Model:       a.Model,
+				Service:     &galah.Service{},
 			}
 			HTTPServer := srv.SetupServer(tt.portConfig)
 			err := srv.StartTLSServer(HTTPServer, tt.portConfig)


### PR DESCRIPTION
## Summary
- connect `internal/server.Server` with `galah.Service`
- remove old `generateResponse` helper
- update server tests to construct a `galah.Service` placeholder
- integrate service creation in the `app` package
- document how to use `galah` as a library

## Testing
- `go test ./...`
