### PR TITLE
Add default paths to galah.NewService

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,4 +209,13 @@ if err != nil {
 fmt.Println(string(respBytes))
 ```
 
+When `galah.NewService` is called with empty `ConfigFile`, `RulesConfigFile`,
+`CacheDBFile`, or `EventLogFile` fields, it automatically uses the same default
+paths as the CLI:
+
+- `config/config.yaml`
+- `config/rules.yaml`
+- `cache.db`
+- `event_log.json`
+
 

--- a/galah/service.go
+++ b/galah/service.go
@@ -21,9 +21,19 @@ const (
 	cacheSize  = 1_000_000
 	lookupTTL  = 1 * time.Hour
 	sessionTTL = 2 * time.Minute
+
+	// Default file paths used when Options fields are left empty.
+	DefaultConfigFile      = "config/config.yaml"
+	DefaultRulesConfigFile = "config/rules.yaml"
+	DefaultCacheDBFile     = "cache.db"
+	DefaultEventLogFile    = "event_log.json"
 )
 
 // Options defines the configuration for creating a Service.
+//
+// If ConfigFile, RulesConfigFile, EventLogFile, or CacheDBFile are empty,
+// NewService falls back to DefaultConfigFile, DefaultRulesConfigFile,
+// DefaultEventLogFile, and DefaultCacheDBFile respectively.
 type Options struct {
 	LLMProvider      string
 	LLMModel         string
@@ -59,6 +69,19 @@ func NewService(ctx context.Context, opts Options) (*Service, error) {
 		if lvl, err := logrus.ParseLevel(opts.LogLevel); err == nil {
 			logger.SetLevel(lvl)
 		}
+	}
+
+	if opts.ConfigFile == "" {
+		opts.ConfigFile = DefaultConfigFile
+	}
+	if opts.RulesConfigFile == "" {
+		opts.RulesConfigFile = DefaultRulesConfigFile
+	}
+	if opts.CacheDBFile == "" {
+		opts.CacheDBFile = DefaultCacheDBFile
+	}
+	if opts.EventLogFile == "" {
+		opts.EventLogFile = DefaultEventLogFile
 	}
 
 	cfg, err := config.LoadConfig(opts.ConfigFile)

--- a/galah/service_test.go
+++ b/galah/service_test.go
@@ -1,0 +1,34 @@
+package galah
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestNewServiceWithDefaults(t *testing.T) {
+	// Ensure working directory is project root so default paths exist.
+	wd, _ := os.Getwd()
+	os.Chdir("..")
+	t.Cleanup(func() { os.Chdir(wd) })
+
+	svc, err := NewService(context.Background(), Options{
+		LLMProvider: "openai",
+		LLMModel:    "gpt-3.5-turbo-1106",
+		LLMAPIKey:   "dummy",
+	})
+	if err != nil {
+		t.Fatalf("NewService returned error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("NewService returned nil service")
+	}
+	// Cleanup files created by defaults
+	t.Cleanup(func() {
+		svc.Cache.Close()
+		os.Remove(DefaultCacheDBFile)
+		os.Remove(DefaultEventLogFile)
+	})
+}


### PR DESCRIPTION
## Summary
- provide default config, rules, cache DB and event log files in `NewService`
- document these defaults
- test creation of a service with empty file path options

## Testing
- `go test ./...`
