### PR TITLE
Add constructor for preloaded config

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,4 +209,16 @@ if err != nil {
 fmt.Println(string(respBytes))
 ```
 
+You can also build a service from an already loaded configuration:
+
+```go
+cfg, _ := config.LoadConfig("config.yaml")
+rulesCfg, _ := config.LoadRules("rules.yaml")
+svc, err := galah.NewServiceFromConfig(context.Background(), cfg, rulesCfg.Rules, galah.Options{
+    LLMProvider: "openai",
+    LLMModel:    "gpt-4.1-mini",
+    LLMAPIKey:   "YOUR_KEY",
+})
+```
+
 

--- a/galah/service.go
+++ b/galah/service.go
@@ -71,6 +71,23 @@ func NewService(ctx context.Context, opts Options) (*Service, error) {
 		return nil, fmt.Errorf("error loading rules config: %w", err)
 	}
 
+	return createService(ctx, cfg, rulesCfg.Rules, opts, logger)
+}
+
+// NewServiceFromConfig initializes a Service using the provided configuration
+// and rule set. The ConfigFile and RulesConfigFile values from opts are ignored.
+func NewServiceFromConfig(ctx context.Context, cfg *config.Config, rules []config.Rule, opts Options) (*Service, error) {
+	logger := logrus.New()
+	if opts.LogLevel != "" {
+		if lvl, err := logrus.ParseLevel(opts.LogLevel); err == nil {
+			logger.SetLevel(lvl)
+		}
+	}
+
+	return createService(ctx, cfg, rules, opts, logger)
+}
+
+func createService(ctx context.Context, cfg *config.Config, rules []config.Rule, opts Options, logger *logrus.Logger) (*Service, error) {
 	modelCfg := llm.Config{
 		Provider:      opts.LLMProvider,
 		Model:         opts.LLMModel,
@@ -103,7 +120,7 @@ func NewService(ctx context.Context, opts Options) (*Service, error) {
 		Cache:         cacheDB,
 		CacheDuration: opts.CacheDuration,
 		Config:        cfg,
-		Rules:         rulesCfg.Rules,
+		Rules:         rules,
 		EventLogger:   eventLogger,
 		LLMConfig:     modelCfg,
 		Logger:        logger,


### PR DESCRIPTION
## Summary
- add `NewServiceFromConfig` for pre-loaded configuration and rules
- refactor constructors to share setup logic
- document new constructor in README

## Testing
- `go test ./...`
