### PR TITLE
Ensure default file paths in NewServiceFromConfig

### DIFF
--- a/galah/service.go
+++ b/galah/service.go
@@ -108,6 +108,19 @@ func NewServiceFromConfig(ctx context.Context, cfg *config.Config, rules []confi
 		}
 	}
 
+	if opts.ConfigFile == "" {
+		opts.ConfigFile = DefaultConfigFile
+	}
+	if opts.RulesConfigFile == "" {
+		opts.RulesConfigFile = DefaultRulesConfigFile
+	}
+	if opts.CacheDBFile == "" {
+		opts.CacheDBFile = DefaultCacheDBFile
+	}
+	if opts.EventLogFile == "" {
+		opts.EventLogFile = DefaultEventLogFile
+	}
+
 	return createService(ctx, cfg, rules, opts, logger)
 }
 

--- a/galah/service_test.go
+++ b/galah/service_test.go
@@ -38,6 +38,30 @@ func TestNewServiceWithDefaults(t *testing.T) {
 	})
 }
 
+func TestNewServiceFromConfigWithDefaults(t *testing.T) {
+	wd, _ := os.Getwd()
+	os.Chdir("..")
+	t.Cleanup(func() { os.Chdir(wd) })
+
+	svc, err := NewServiceFromConfig(context.Background(), &config.Config{}, nil, Options{
+		LLMProvider: "openai",
+		LLMModel:    "gpt-3.5-turbo-1106",
+		LLMAPIKey:   "dummy",
+	})
+	if err != nil {
+		t.Fatalf("NewServiceFromConfig returned error: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("NewServiceFromConfig returned nil service")
+	}
+
+	t.Cleanup(func() {
+		svc.Cache.Close()
+		os.Remove(DefaultCacheDBFile)
+		os.Remove(DefaultEventLogFile)
+	})
+}
+
 type MockModel struct {
 	GenerateContentFunc func(ctx context.Context, messages []llms.MessageContent, opts ...llms.CallOption) (*llms.ContentResponse, error)
 }


### PR DESCRIPTION
## Summary
- match fallback logic between `NewService` and `NewServiceFromConfig`
- add unit test verifying the defaults work when using `NewServiceFromConfig`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_687ebbac55d08331ab6211b5f039a961